### PR TITLE
Small changes to VideoPlayer and CameraInfo

### DIFF
--- a/rover_gui/CMakeLists.txt
+++ b/rover_gui/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 project(rover_gui)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD 23)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/rover_gui/src/QVideoPlayer/QVideoManagerWidget.cpp
+++ b/rover_gui/src/QVideoPlayer/QVideoManagerWidget.cpp
@@ -6,7 +6,6 @@ QVideoManagerWidget::QVideoManagerWidget(std::shared_ptr<rclcpp::Node> guiNode_,
     _node(guiNode_),
     _videoPlayerLayout(this),
     _playerWorkerThread(std::make_shared<QPlayerWorker>())
-
 {
     this->initWidget();
 
@@ -39,7 +38,7 @@ void QVideoManagerWidget::CB_displayArucoDetected(rover_msgs::msg::Aruco msg_)
 
     for (auto& widget : _videoPlaysWidgets)
     {
-        if (widget != nullptr && widget->getCamURL() == url)
+        if (widget && widget->getCamURL() == url)
         {
             widget->displayDetectedArucos(detectedIds);
             emit widget->arucoCameraFailure(msg_.valid);
@@ -54,7 +53,7 @@ void QVideoManagerWidget::onArucoDetectionIsLive(std::vector<std::string> liveUr
         bool urlFound = false;
         for (const auto& url : liveUrlList_)
         {
-            if (widget->getCamURL() == url)
+            if (widget && widget->getCamURL() == url)
             {
                 urlFound = true;
                 break;
@@ -68,21 +67,30 @@ void QVideoManagerWidget::initWidget(void)
 {
     for (size_t i = 0UL; i < NBR_CAM_TO_TRACK; ++i)
     {
-        std::shared_ptr<QVideoPlayerWidget> widget
-            = std::make_shared<QVideoPlayerWidget>(_node, this, _cameras_urls[i], i, _playerWorkerThread);
+        std::string cameraUrl = "";
+        if (i < CAMERA_NAME_ORDER.size() && CameraInfo::CAMERA_URL_MAP.find(CAMERA_NAME_ORDER[i]) != CameraInfo::CAMERA_URL_MAP.end())
+        {
+            cameraUrl = CameraInfo::CAMERA_URL_MAP.at(CAMERA_NAME_ORDER[i]);
+        }
+        else if (i < CAMERA_NAME_ORDER.size())
+        {
+            RCLCPP_WARN(rclcpp::get_logger("GUI"), "Couldn't find url for camera named %s in camera infos.", CAMERA_NAME_ORDER[i]);
+        }
 
-        widget->setObjectName(QString("camera%1_widget").arg(i + 1));
-
-        _videoPlaysWidgets[i] = widget;
+        _videoPlaysWidgets[i] = std::make_unique<QVideoPlayerWidget>(_node, cameraUrl, i, _playerWorkerThread);
+        _videoPlaysWidgets[i]->setObjectName(QString("camera%1_widget").arg(i + 1));
     }
 
     uint16_t index = 0;
     for (auto& widget : _videoPlaysWidgets)
     {
-        int row = index / 3;
-        int col = index % 3;
-        _videoPlayerLayout.addWidget(widget.get(), row, col);
-        index++;
+        if (widget)
+        {
+            int row = index / 3;
+            int col = index % 3;
+            _videoPlayerLayout.addWidget(widget.get(), row, col);
+            index++;
+        }
     }
 }
 
@@ -116,7 +124,10 @@ void QVideoManagerWidget::initArucoClient(void)
 
     for (auto& widget : _videoPlaysWidgets)
     {
-        widget->setArucoClientManager(_client_arucoDetectionManager);
+        if (widget)
+        {
+            widget->setArucoClientManager(_client_arucoDetectionManager);
+        }
     }
 
     _timer_detectionManagerUpdate = _node->create_wall_timer(std::chrono::milliseconds(DELAY_DETECTION_MANAGER_UPDATE),

--- a/rover_gui/src/QVideoPlayer/QVideoManagerWidget.cpp
+++ b/rover_gui/src/QVideoPlayer/QVideoManagerWidget.cpp
@@ -68,13 +68,16 @@ void QVideoManagerWidget::initWidget(void)
     for (size_t i = 0UL; i < NBR_CAM_TO_TRACK; ++i)
     {
         std::string cameraUrl = "";
-        if (i < CAMERA_NAME_ORDER.size() && CameraInfo::CAMERA_URL_MAP.find(CAMERA_NAME_ORDER[i]) != CameraInfo::CAMERA_URL_MAP.end())
+        if (i < CAMERA_NAME_ORDER.size()
+            && CameraInfo::CAMERA_URL_MAP.find(CAMERA_NAME_ORDER[i]) != CameraInfo::CAMERA_URL_MAP.end())
         {
             cameraUrl = CameraInfo::CAMERA_URL_MAP.at(CAMERA_NAME_ORDER[i]);
         }
         else if (i < CAMERA_NAME_ORDER.size())
         {
-            RCLCPP_WARN(rclcpp::get_logger("GUI"), "Couldn't find url for camera named %s in camera infos.", CAMERA_NAME_ORDER[i]);
+            RCLCPP_WARN(rclcpp::get_logger("GUI"),
+                        "Couldn't find url for camera named %s in camera infos.",
+                        CAMERA_NAME_ORDER[i]);
         }
 
         _videoPlaysWidgets[i] = std::make_unique<QVideoPlayerWidget>(_node, cameraUrl, i, _playerWorkerThread);

--- a/rover_gui/src/QVideoPlayer/QVideoManagerWidget.hpp
+++ b/rover_gui/src/QVideoPlayer/QVideoManagerWidget.hpp
@@ -16,12 +16,13 @@ class QVideoManagerWidget : public QWidget
 
     static constexpr uint16_t DELAY_DETECTION_MANAGER_UPDATE = 500U;
     static constexpr uint16_t NBR_CAM_TO_TRACK = 6U;
-    static constexpr const char* CAM_1_NAME = "Main";
-    static constexpr const char* CAM_2_NAME = "Antenna";
-    static constexpr const char* CAM_3_NAME = "Odometry";
-    static constexpr const char* CAM_4_NAME = "Gripper1";
-    static constexpr const char* CAM_5_NAME = "Gripper2";
-    static constexpr const char* CAM_6_NAME = "";
+    static constexpr std::array<const char*, 5> CAMERA_NAME_ORDER = {
+        "Main",
+        "Antenna",
+        "Front-Side",
+        "Arm-Top",
+        "Arm-Side",
+    };
 
   public:
     QVideoManagerWidget(std::shared_ptr<rclcpp::Node> guiNode_, QWidget* parent_);
@@ -47,13 +48,7 @@ class QVideoManagerWidget : public QWidget
     std::shared_ptr<rclcpp::Subscription<rover_msgs::msg::Aruco>> _sub_arucoDetection;
     rclcpp::TimerBase::SharedPtr _timer_detectionManagerUpdate;
 
-    std::array<std::shared_ptr<QVideoPlayerWidget>, NBR_CAM_TO_TRACK> _videoPlaysWidgets;
-    std::array<std::string, 6> _cameras_urls = {CameraInfo::CameraIP.at(CAM_1_NAME),
-                                                CameraInfo::CameraIP.at(CAM_2_NAME),
-                                                CameraInfo::CameraIP.at(CAM_3_NAME),
-                                                CameraInfo::CameraIP.at(CAM_4_NAME),
-                                                CameraInfo::CameraIP.at(CAM_5_NAME),
-                                                ""};
+    std::array<std::unique_ptr<QVideoPlayerWidget>, NBR_CAM_TO_TRACK> _videoPlaysWidgets;
 };
 
 #endif  // QVIDEO_PLAYER_HPP

--- a/rover_gui/src/QVideoPlayer/QVideoPlayerWidget.cpp
+++ b/rover_gui/src/QVideoPlayer/QVideoPlayerWidget.cpp
@@ -2,11 +2,9 @@
 #include <QStyle>
 
 QVideoPlayerWidget::QVideoPlayerWidget(std::shared_ptr<rclcpp::Node> guiNode_,
-                                       QWidget* parent_,
                                        std::string url_,
                                        uint16_t tag_,
                                        std::shared_ptr<QPlayerWorker> worker_):
-    QWidget(parent_),
     _node(guiNode_),
     _camURL(url_),
     _tag(tag_),
@@ -175,7 +173,7 @@ void QVideoPlayerWidget::onArucoServerInfoFailed(bool success_)
 {
     if (!success_)
     {
-        RCLCPP_WARN(rclcpp::get_logger("GUI"), "Error, info request to aruco detection manager client failed");
+        RCLCPP_DEBUG(rclcpp::get_logger("GUI"), "Error, info request to aruco detection manager client failed");
         _ui.arucoPushButton->setEnabled(false);
     }
     else

--- a/rover_gui/src/QVideoPlayer/QVideoPlayerWidget.hpp
+++ b/rover_gui/src/QVideoPlayer/QVideoPlayerWidget.hpp
@@ -18,7 +18,6 @@ class QVideoPlayerWidget : public QWidget
 
   public:
     QVideoPlayerWidget(std::shared_ptr<rclcpp::Node> guiNode_,
-                       QWidget* parent_,
                        std::string url_,
                        uint16_t tag_,
                        std::shared_ptr<QPlayerWorker> worker_);
@@ -54,7 +53,7 @@ class QVideoPlayerWidget : public QWidget
     std::string _defaultCamUrl = "";
     uint16_t _tag;
 
-    std::shared_ptr<rclcpp::Client<rover_msgs::srv::ArucoDetection>> _client_arucoManager = nullptr;
+    std::shared_ptr<rclcpp::Client<rover_msgs::srv::ArucoDetection>> _client_arucoManager;
 
     std::shared_ptr<QPlayerWorker> _playerWorkerThread;
 };

--- a/rover_gui/ui/ui/VideoPlayer.ui
+++ b/rover_gui/ui/ui/VideoPlayer.ui
@@ -6,124 +6,201 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>532</height>
+    <width>455</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QFrame" name="frame">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>70</y>
-     <width>571</width>
-     <height>451</height>
-    </rect>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::StyledPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Raised</enum>
-   </property>
-  </widget>
-  <widget class="QWidget" name="VideoPlayerlayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>40</y>
-     <width>571</width>
-     <height>27</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QPushButton" name="arucoPushButton">
-      <property name="text">
-       <string>Aruco Detection</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QLineEdit" name="arucoIdsTextBox">
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="ScreenshotButton">
-      <property name="text">
-       <string>Screenshot</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="startRecordingButton">
-      <property name="text">
-       <string>Start Recording</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>11</x>
-     <y>10</y>
-     <width>571</width>
-     <height>27</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout_2">
-    <item>
-     <widget class="QPushButton" name="playPauseButton">
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="icon">
-       <iconset theme="media-playback-pause">
-        <normaloff>.</normaloff>.</iconset>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QLineEdit" name="rtspTextBox">
-      <property name="readOnly">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="defaultStreamPushButton">
-      <property name="text">
-       <string>default</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>3</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="rtspTextBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="defaultStreamPushButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset theme="view-refresh"/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="playPauseButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset theme="media-playback-pause">
+           <normaloff>.</normaloff>.</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="spacing">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="arucoPushButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Aruco Detection</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="arucoIdsTextBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="ScreenshotButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset theme="camera-photo"/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="startRecordingButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset theme="media-record"/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/rover_msgs/CMakeLists.txt
+++ b/rover_msgs/CMakeLists.txt
@@ -39,7 +39,8 @@ find_package(rclcpp REQUIRED)
 include_directories(include)
 add_library(lib_exec src/lib.cpp
               include/rovus_lib/timer.cpp
-              include/rovus_lib/ip_pinging.cpp)
+              include/rovus_lib/ip_pinging.cpp
+              include/rovus_lib/camera_info.cpp)
               
 ament_target_dependencies(lib_exec 
                             ament_index_cpp 

--- a/rover_msgs/include/rovus_lib/camera_info.cpp
+++ b/rover_msgs/include/rovus_lib/camera_info.cpp
@@ -4,11 +4,14 @@ namespace CameraInfo
 {
     bool getNameFromURL(const std::string& url_, std::string& rName_)
     {
-        std::map<std::string, std::string> cameraNameMap;
-        for (const auto& [key, value] : CAMERA_URL_MAP)
-        {
-            cameraNameMap[value] = key;
-        }
+        static std::map<std::string, std::string> cameraNameMap = []() {
+            std::map<std::string, std::string> tempMap;
+            for (const auto& [key, value] : CAMERA_URL_MAP)
+            {
+                tempMap[value] = key;
+            }
+            return tempMap;
+        }();
         
         auto it = cameraNameMap.find(url_);
         if (it != cameraNameMap.end())

--- a/rover_msgs/include/rovus_lib/camera_info.cpp
+++ b/rover_msgs/include/rovus_lib/camera_info.cpp
@@ -1,0 +1,24 @@
+#include "camera_info.hpp"
+
+namespace CameraInfo
+{
+    bool getNameFromURL(const std::string& url_, std::string& rName_)
+    {
+        std::map<std::string, std::string> cameraNameMap;
+        for (const auto& [key, value] : CAMERA_URL_MAP)
+        {
+            cameraNameMap[value] = key;
+        }
+        
+        auto it = cameraNameMap.find(url_);
+        if (it != cameraNameMap.end())
+        {
+            rName_ = it->second;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}  // namespace CameraInfo

--- a/rover_msgs/include/rovus_lib/camera_info.cpp
+++ b/rover_msgs/include/rovus_lib/camera_info.cpp
@@ -4,7 +4,8 @@ namespace CameraInfo
 {
     bool getNameFromURL(const std::string& url_, std::string& rName_)
     {
-        static std::map<std::string, std::string> cameraNameMap = []() {
+        static std::map<std::string, std::string> cameraNameMap = []()
+        {
             std::map<std::string, std::string> tempMap;
             for (const auto& [key, value] : CAMERA_URL_MAP)
             {
@@ -12,7 +13,7 @@ namespace CameraInfo
             }
             return tempMap;
         }();
-        
+
         auto it = cameraNameMap.find(url_);
         if (it != cameraNameMap.end())
         {

--- a/rover_msgs/include/rovus_lib/camera_info.hpp
+++ b/rover_msgs/include/rovus_lib/camera_info.hpp
@@ -1,26 +1,27 @@
-#ifndef __CAMERA__INFO__HPP__
-#define __CAMERA__INFO__HPP__
+#ifndef CAMERA_INFO_HPP
+#define CAMERA_INFO_HPP
 
 #include <map>
 #include <string>
 
 namespace CameraInfo
 {
-    const std::map<std::string, std::string> CameraName = {
-        {"rtsp://rover:roverrover@192.168.144.30:554/1/h264major", "Main"},
-        {"rtsp://rover:roverrover@192.168.144.31:554/1/h264major", "Antenna"},
-        {"rtsp://rover:roverrover@192.168.144.32:554/1/h264major", "Odometry"},
-        {"rtsp://rover:roverrover@192.168.144.35:554/1/h264major", "Gripper1"},
-        {"rtsp://rover:roverrover@192.168.144.36:554/1/h264major", "Gripper2"},
+    const std::map<std::string, std::string> CAMERA_URL_MAP = {
+        {"Main", "rtsp://192.168.144.30:554/1/h264major"},
+        {"Antenna", "rtsp://192.168.144.31:554/1/h264major"},
+        {"Front-Side", "rtsp://192.168.144.32:554/1/h264major"},
+        {"Arm-Top", "rtsp://192.168.144.35:554/1/h264major"},
+        {"Arm-Side", "rtsp://192.168.144.36:554/1/h264major"},
     };
-
-    const std::map<std::string, std::string> CameraIP = {
-        {"Main", "rtsp://rover:roverrover@192.168.144.30:554/1/h264major"},
-        {"Antenna", "rtsp://rover:roverrover@192.168.144.31:554/1/h264major"},
-        {"Odometry", "rtsp://rover:roverrover@192.168.144.32:554/1/h264major"},
-        {"Gripper1", "rtsp://rover:roverrover@192.168.144.35:554/1/h264major"},
-        {"Gripper2", "rtsp://rover:roverrover@192.168.144.36:554/1/h264major"},
-    };
+    
+    /**
+     * @brief Tries to find a name from a camera URL
+     *
+     * @param url_ URL of the camera
+     * @param rName_ Overwrite value if found
+     * @return Success on camera name found
+     */
+    bool getNameFromURL(const std::string& url_, std::string& rName_);
 }  // namespace CameraInfo
 
-#endif  //__CAMERA__INFO__HPP__
+#endif  // CAMERA_INFO_HPP

--- a/rover_msgs/include/rovus_lib/camera_info.hpp
+++ b/rover_msgs/include/rovus_lib/camera_info.hpp
@@ -13,7 +13,7 @@ namespace CameraInfo
         {"Arm-Top", "rtsp://192.168.144.35:554/1/h264major"},
         {"Arm-Side", "rtsp://192.168.144.36:554/1/h264major"},
     };
-    
+
     /**
      * @brief Tries to find a name from a camera URL
      *

--- a/rover_video/src/camera_node.cpp
+++ b/rover_video/src/camera_node.cpp
@@ -10,10 +10,6 @@ int main(int argc, char* argv[])
     return 0;
 }
 
-/**
- * @brief Construct a new CameraNode object
- *
- */
 CameraNode::CameraNode():
     Node("media_server")
 {
@@ -39,12 +35,6 @@ CameraNode::CameraNode():
                                                                   });
 }
 
-/**
- * @brief Decides what to do depending on the oncoming request
- *
- * @param request_
- * @param response_
- */
 void CameraNode::controlIPCam(const rover_msgs::srv::CameraControl::Request& request_,
                               rover_msgs::srv::CameraControl::Response& response_)
 {
@@ -84,12 +74,6 @@ void CameraNode::controlIPCam(const rover_msgs::srv::CameraControl::Request& req
     }
 }
 
-/**
- * @brief Executes the program in order to take a screenshot
- *
- * @param request_
- * @param response_
- */
 void CameraNode::takeScreenshot(const rover_msgs::srv::CameraControl::Request& request_,
                                 rover_msgs::srv::CameraControl::Response& response_)
 {
@@ -100,12 +84,7 @@ void CameraNode::takeScreenshot(const rover_msgs::srv::CameraControl::Request& r
 
     captureName = this->getFileName(request_.capture_name, cameraURL, eFileFormatNameTypes::SCREENSHOT);
     folderPath = this->getFolderPath(eFileFormatNameTypes::SCREENSHOT);
-    auto it = CameraInfo::CameraName.find(cameraURL);
-
-    if (it != CameraInfo::CameraName.end())
-    {
-        currentCamera = it->second;
-    }
+    CameraInfo::getNameFromURL(cameraURL, currentCamera);
 
     if (!this->createFolder(folderPath))
     {
@@ -130,12 +109,6 @@ void CameraNode::takeScreenshot(const rover_msgs::srv::CameraControl::Request& r
     }
 }
 
-/**
- * @brief Executes the program in order when a new recording starts
- *
- * @param request_
- * @param response_
- */
 void CameraNode::startRecordingLogic(const rover_msgs::srv::CameraControl::Request& request_,
                                      rover_msgs::srv::CameraControl::Response& response_)
 {
@@ -146,12 +119,7 @@ void CameraNode::startRecordingLogic(const rover_msgs::srv::CameraControl::Reque
 
     captureName = this->getFileName(request_.capture_name, cameraURL, eFileFormatNameTypes::VIDEO);
     folderPath = this->getFolderPath(eFileFormatNameTypes::VIDEO);
-    auto it = CameraInfo::CameraName.find(cameraURL);
-
-    if (it != CameraInfo::CameraName.end())
-    {
-        currentCamera = it->second;
-    }
+    CameraInfo::getNameFromURL(cameraURL, currentCamera);
 
     if (!this->createFolder(folderPath))
     {
@@ -176,12 +144,6 @@ void CameraNode::startRecordingLogic(const rover_msgs::srv::CameraControl::Reque
     }
 }
 
-/**
- * @brief Executes the program in order when a recording stops
- *
- * @param request_
- * @param response_
- */
 void CameraNode::stopRecordingLogic(const rover_msgs::srv::CameraControl::Request& request_,
                                     rover_msgs::srv::CameraControl::Response& response_)
 {
@@ -199,11 +161,6 @@ void CameraNode::stopRecordingLogic(const rover_msgs::srv::CameraControl::Reques
     }
 }
 
-/**
- * @brief Get the time the request was made
- *
- * @return std::string
- */
 std::string CameraNode::getCurrentTime(void)
 {
     std::stringstream current_time_output;
@@ -232,12 +189,7 @@ std::string CameraNode::getFileName(const std::string& capture_name_, std::strin
     std::string latitude = std::to_string(_lastLatitude);
     std::string longitude = std::to_string(_lastLongitude);
     std::string ID = "UnknownID";
-    auto it = CameraInfo::CameraName.find(camURL_);
-
-    if (it != CameraInfo::CameraName.end())
-    {
-        ID = it->second;
-    }
+    CameraInfo::getNameFromURL(camURL_, ID);
 
     switch (fileType_)
     {


### PR DESCRIPTION
Switch to icons in videoplayer:
- It's uglier but allows more space for the camera url, I added a task in project to generate/make better looking icons for UI.

Fixed invalid name crash in default cameras videoplayer.
- If the CameraInfo map was changed the videoplayermanager would crash at construction, i've added a check before construction so now it constructs with defaults value instead of crashing if the camera name is invalid.

Also reoganized a bit the CameraInfo Namespace