### PR TITLE
Revert "Added namespace in RoverLib2 macros to prevent conflicts (#138)"

### DIFF
--- a/rover_arm/include/joy_manager.hpp
+++ b/rover_arm/include/joy_manager.hpp
@@ -38,7 +38,7 @@ class JoyManager
     }
     bool isPressed(eJoyInput joyInput_)
     {
-        return !RoverLib2::IN_ERROR(_joyInputArray[TO_UNDERLYING(joyInput_)], DEADZONE, NEUTRAL);
+        return !IN_ERROR(_joyInputArray[TO_UNDERLYING(joyInput_)], DEADZONE, NEUTRAL);
     }
     bool isTriggered(eJoyInput joyInput_)
     {

--- a/rover_camera/src/video_recording.cpp
+++ b/rover_camera/src/video_recording.cpp
@@ -168,7 +168,7 @@ bool Recording::startRecording(void)
     _frameHeight = static_cast<int>(std::round(_cap.get(cv::CAP_PROP_FRAME_HEIGHT)));
     _fps = _cap.get(cv::CAP_PROP_FPS);
 
-    _fps = RoverLib2::CONSTRAIN(_fps, 0.0, 30.0);
+    _fps = CONSTRAIN(_fps, 0.0, 30.0);
 
     RCLCPP_DEBUG(rLogger, "fps set to %f", _fps);
 

--- a/rover_can/src/can_master/devices/camera.hpp
+++ b/rover_can/src/can_master/devices/camera.hpp
@@ -17,7 +17,7 @@ class Camera : public RoverCan2::Device<RoverCan2::Publisher<RoverCan2::Msgs::Po
     static constexpr const char* CAMERA_POWER_STATUS_TOPIC = "/rover/cameras/power_status";
     static constexpr float CAMERA_POWER_STATUS_PUB_FREQ = 2.0F;
     static constexpr uint32_t CAMERA_POWER_STATUS_PUB_PERIOD_MS
-        = static_cast<uint32_t>(RoverLib2::ROUND(1'000.0F / CAMERA_POWER_STATUS_PUB_FREQ));
+        = static_cast<uint32_t>(ROUND(1'000.0F / CAMERA_POWER_STATUS_PUB_FREQ));
     static constexpr const char* CAMERA_POWER_CONTROL_TOPIC = "/rover/cameras/status";
 
   public:

--- a/rover_can/src/can_master/devices/propulsion_motors.hpp
+++ b/rover_can/src/can_master/devices/propulsion_motors.hpp
@@ -22,7 +22,7 @@ class PropulsionMotor : public RoverCan2::Device<RoverCan2::Publisher<RoverCan2:
     static constexpr float PROPULSION_MOTOR_STATUS_PUBLISH_FREQUENCY_HZ = 100.0F;
 
     static constexpr float CAN_PUBLISH_FREQUENCY = 20.0F;
-    static constexpr uint32_t CAN_PUBLISH_PERIOD_MS = static_cast<uint32_t>(RoverLib2::ROUND(1'000.0F / CAN_PUBLISH_FREQUENCY));
+    static constexpr uint32_t CAN_PUBLISH_PERIOD_MS = static_cast<uint32_t>(ROUND(1'000.0F / CAN_PUBLISH_FREQUENCY));
 
   public:
     PropulsionMotor(RoverCan2::Constant::eDeviceId deviceId_,

--- a/rover_can/src/can_master/shared_msg.hpp
+++ b/rover_can/src/can_master/shared_msg.hpp
@@ -37,7 +37,7 @@ namespace CanMaster
                 RCLCPP_WARN(_node->get_logger(), "Expected publish rate be in range [0, 1000]. Value asked by user: %.2f", rate_);
             }
 
-            rate_ = RoverLib2::CONSTRAIN(rate_, 0.0F, 1000.0F);
+            rate_ = CONSTRAIN(rate_, 0.0F, 1000.0F);
             if (_node || rate_ > _rate)
             {
                 _rate = rate_;

--- a/rover_gui/src/QSshFileExplorer/Worker/QSshWorker.cpp
+++ b/rover_gui/src/QSshFileExplorer/Worker/QSshWorker.cpp
@@ -317,8 +317,8 @@ void QSshWorker::downloadFileInternal(IN const std::string& rUsername_,
         {
             localFile.write(reinterpret_cast<const char*>(buffer), nbytes);
 
-            totalBytesRead += static_cast<uint64_t>(
-                RoverLib2::CONSTRAIN(nbytes, static_cast<ssize_t>(0), static_cast<ssize_t>(sizeof(buffer))));
+            totalBytesRead
+                += static_cast<uint64_t>(CONSTRAIN(nbytes, static_cast<ssize_t>(0), static_cast<ssize_t>(sizeof(buffer))));
             progress = 100.0f * static_cast<float>(totalBytesRead) / static_cast<float>(fileSize);
             if (totalBytesRead != 0 && fileSize != 0)
             {

--- a/rover_joy/src/joy_formator.cpp
+++ b/rover_joy/src/joy_formator.cpp
@@ -204,26 +204,24 @@ void JoyFormator::callbackPubJoy()
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::EXT2] = getJoyValue<bool>(Keybinding::ext2);
 
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::JOYSTICK_LEFT_FRONT]
-        = applyJoystickDeadZone((RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::joystick_left_front), -1.0f, 1.0f)));
+        = applyJoystickDeadZone((CONSTRAIN(getJoyValue<float>(Keybinding::joystick_left_front), -1.0f, 1.0f)));
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::JOYSTICK_LEFT_SIDE]
-        = applyJoystickDeadZone((RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::joystick_left_side), -1.0f, 1.0f)));
+        = applyJoystickDeadZone((CONSTRAIN(getJoyValue<float>(Keybinding::joystick_left_side), -1.0f, 1.0f)));
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::JOYSTICK_RIGHT_FRONT]
-        = applyJoystickDeadZone((RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::joystick_right_front), -1.0f, 1.0f)));
+        = applyJoystickDeadZone((CONSTRAIN(getJoyValue<float>(Keybinding::joystick_right_front), -1.0f, 1.0f)));
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::JOYSTICK_RIGHT_SIDE]
-        = applyJoystickDeadZone((RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::joystick_right_side), -1.0f, 1.0f)));
+        = applyJoystickDeadZone((CONSTRAIN(getJoyValue<float>(Keybinding::joystick_right_side), -1.0f, 1.0f)));
 
-    formatted_joy_msg.joy_data[rover_msgs::msg::Joy::L2]
-        = MAP(RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::l2), -1.0f, 1.0f),
-              _controller_config.trigger_range_min,
-              _controller_config.trigger_range_max,
-              0.0f,
-              1.0f);
-    formatted_joy_msg.joy_data[rover_msgs::msg::Joy::R2]
-        = MAP(RoverLib2::CONSTRAIN(getJoyValue<float>(Keybinding::r2), -1.0f, 1.0f),
-              _controller_config.trigger_range_min,
-              _controller_config.trigger_range_max,
-              0.0f,
-              1.0f);
+    formatted_joy_msg.joy_data[rover_msgs::msg::Joy::L2] = MAP(CONSTRAIN(getJoyValue<float>(Keybinding::l2), -1.0f, 1.0f),
+                                                               _controller_config.trigger_range_min,
+                                                               _controller_config.trigger_range_max,
+                                                               0.0f,
+                                                               1.0f);
+    formatted_joy_msg.joy_data[rover_msgs::msg::Joy::R2] = MAP(CONSTRAIN(getJoyValue<float>(Keybinding::r2), -1.0f, 1.0f),
+                                                               _controller_config.trigger_range_min,
+                                                               _controller_config.trigger_range_max,
+                                                               0.0f,
+                                                               1.0f);
 
     float cross_temp = getJoyValue<float>(Keybinding::cross_front);
     formatted_joy_msg.joy_data[rover_msgs::msg::Joy::CROSS_UP] = cross_temp > 0.0f ? true : false;    // cross up
@@ -336,7 +334,7 @@ T JoyFormator::getJoyValue(Keybinding::eKeybinding key_)
 
 float JoyFormator::applyJoystickDeadZone(float value_)
 {
-    if (!RoverLib2::IN_ERROR(value_, _controller_config.joystick_dead_zone, 0.0f))
+    if (!IN_ERROR(value_, _controller_config.joystick_dead_zone, 0.0f))
     {
         return SIGN(value_) * MAP(abs(value_), _controller_config.joystick_dead_zone, 1.0f, 0.0f, 1.0f);
     }

--- a/rover_shared_libs/rover_lib2/src/rover_lib2/LED/led_blinker.hpp
+++ b/rover_shared_libs/rover_lib2/src/rover_lib2/LED/led_blinker.hpp
@@ -138,8 +138,7 @@ namespace LED
                 _targetTimeStep = static_cast<uint64_t>(_pattern[_currentStep].durationMs);
                 _chronoStep.restart();
 
-                uint8_t stepIntensity
-                    = RoverLib2::CONSTRAIN(_pattern[_currentStep].intensity, static_cast<uint8_t>(0), _maxIntensity);
+                uint8_t stepIntensity = CONSTRAIN(_pattern[_currentStep].intensity, static_cast<uint8_t>(0), _maxIntensity);
 
                 if (stepIntensity == 0)
                 {
@@ -154,7 +153,7 @@ namespace LED
                 else
                 {
                     _currentLedState = eState::DIMMED;
-                    triggerCtnTarget = RoverLib2::CONSTRAIN(stepIntensity, static_cast<uint8_t>(0), INTENSITY_RESOLUTION);
+                    triggerCtnTarget = CONSTRAIN(stepIntensity, static_cast<uint8_t>(0), INTENSITY_RESOLUTION);
                     triggerCtn = 0UL;
                     _led.write(IO::eIOState::HIGH_);
                 }

--- a/rover_shared_libs/rover_lib2/src/rover_lib2/actuators/PWM_generators/MCPWM.hpp
+++ b/rover_shared_libs/rover_lib2/src/rover_lib2/actuators/PWM_generators/MCPWM.hpp
@@ -92,7 +92,7 @@ namespace PWMGenerators
 
         void _setDutyCycle(float duty_)
         {
-            _duty = RoverLib2::CONSTRAIN(duty_, 0.0F, 100.0F);
+            _duty = CONSTRAIN(duty_, 0.0F, 100.0F);
             uint32_t activePeriodCtn = _timer.dutyToTickCtn(_duty);
 
             if (!_timer.isEnable())

--- a/rover_shared_libs/rover_lib2/src/rover_lib2/actuators/PWM_generators/MCPWM_timer.hpp
+++ b/rover_shared_libs/rover_lib2/src/rover_lib2/actuators/PWM_generators/MCPWM_timer.hpp
@@ -48,12 +48,11 @@ namespace PWMGenerators
             _frequency(1.0F),
             _resolutionHz(MAX_TICK_VALUE - 1),  // Fallback values should never trigger
             _timerPeriodTick(MAX_TICK_VALUE),   // Fallback values
-            _groupID(RoverLib2::CONSTRAIN(peripheralGroupId_,
-                                          static_cast<eMCPWMGroupID>(0),
-                                          static_cast<eMCPWMGroupID>(SOC_MCPWM_GROUPS - 1))),
+            _groupID(
+                CONSTRAIN(peripheralGroupId_, static_cast<eMCPWMGroupID>(0), static_cast<eMCPWMGroupID>(SOC_MCPWM_GROUPS - 1))),
             _enabled(false)
         {
-            _frequency = RoverLib2::CONSTRAIN(frequency_, 1UL, CLOCK_FREQUENCY_HZ);
+            _frequency = CONSTRAIN(frequency_, 1UL, CLOCK_FREQUENCY_HZ);
             MCPWMTimer::calculateResTickFromFreq(static_cast<uint32_t>(_frequency), _resolutionHz, _timerPeriodTick);
 
             _frequency = static_cast<float>(_resolutionHz / static_cast<float>(_timerPeriodTick + 1));
@@ -204,8 +203,7 @@ namespace PWMGenerators
         {
             if (frequency_ > MAX_TICK_VALUE)
             {
-                rTickPeriod_
-                    = static_cast<uint32_t>(RoverLib2::ROUND(static_cast<float>(CLOCK_FREQUENCY_HZ / frequency_) - 1.0F));
+                rTickPeriod_ = static_cast<uint32_t>(ROUND(static_cast<float>(CLOCK_FREQUENCY_HZ / frequency_) - 1.0F));
                 if (rTickPeriod_ == 0)
                 {
                     ASSERT_MSG_ARGS("Requested frequency yielded timer period in tick of 0. With selected clock (%u Hz) "

--- a/rover_shared_libs/rover_lib2/src/rover_lib2/helpers/macros.hpp
+++ b/rover_shared_libs/rover_lib2/src/rover_lib2/helpers/macros.hpp
@@ -8,16 +8,12 @@
 #include <ament_index_cpp/get_package_prefix.hpp>
 #endif  // defined(__linux__) && defined(RCLCPP_DEBUG)
 
-// Not in namespace to keep backward compatibility
 template<typename ENUM_T>
 constexpr std::underlying_type_t<ENUM_T> TO_UNDERLYING(ENUM_T e) noexcept
 {
     static_assert(std::is_enum_v<ENUM_T>, "TO_UNDERLYING() can only be used with enum types");
     return static_cast<std::underlying_type_t<ENUM_T>>(e);
 }
-
-namespace RoverLib2
-{
 
 #if !defined(ARDUINO_ESP32S3_DEV)
 #define __FILENAME__ (__builtin_strrchr("/" __FILE__, '/') + 1)
@@ -54,98 +50,97 @@ namespace RoverLib2
     static_assert((... && std::is_base_of_v<BaseT, std::remove_reference_t<__VA_ARGS__>>), \
                   "All template arguments must be derived from " #BaseT)
 
-    template<typename T>
-    constexpr T ABS(T var_) noexcept
+template<typename T>
+constexpr T ABS(T var_) noexcept
+{
+    if constexpr (std::is_unsigned_v<T>)
     {
-        if constexpr (std::is_unsigned_v<T>)
-        {
-            return var_;
-        }
-        else
-        {
-            return ((var_ < static_cast<T>(0)) ? -var_ : var_);
-        }
+        return var_;
     }
-
-    template<typename T>
-    constexpr bool IN_ERROR(T var_, T error_, T goal_)
+    else
     {
-        error_ = ABS(error_);
-        return var_ <= (goal_ + error_) && var_ >= (goal_ - error_);
+        return ((var_ < static_cast<T>(0)) ? -var_ : var_);
     }
+}
 
-    template<typename T>
-    constexpr T CONSTRAIN(T value_, T min_, T max_)
+template<typename T>
+constexpr bool IN_ERROR(T var_, T error_, T goal_)
+{
+    error_ = ABS(error_);
+    return var_ <= (goal_ + error_) && var_ >= (goal_ - error_);
+}
+
+template<typename T>
+constexpr T CONSTRAIN(T value_, T min_, T max_)
+{
+    if (value_ < min_)
     {
-        if (value_ < min_)
-        {
-            return min_;
-        }
-        else if (value_ > max_)
-        {
-            return max_;
-        }
-        else
-        {
-            return value_;
-        }
+        return min_;
     }
-
-    /**
-     * @brief Truncate a floating-point value (remove fractional part).
-     */
-    template<std::floating_point T>
-    constexpr T TRUNC(T value_)
+    else if (value_ > max_)
     {
-        return (value_ == 0) ? value_ :  // Handle ±0.0
-                   (value_ > 0) ? static_cast<T>(static_cast<int64_t>(value_))
-                                : static_cast<T>(static_cast<int64_t>(value_ - static_cast<T>(1.0)) + static_cast<T>(1.0));
+        return max_;
     }
-
-    /**
-     * @brief Round a floating-point value to the nearest integer
-     */
-    template<std::floating_point T>
-    constexpr T ROUND(T value_)
+    else
     {
-        T absValue = ABS(value_);
-        T fractionalPart = absValue - static_cast<int64_t>(absValue);
-
-        if (fractionalPart >= static_cast<T>(0.5))
-        {
-            return (value_ < 0) ? static_cast<T>(static_cast<int64_t>(value_) - 1)
-                                : static_cast<T>(static_cast<int64_t>(value_) + 1);
-        }
-        return static_cast<T>(static_cast<int64_t>(value_));
+        return value_;
     }
+}
 
-    /**
-     * @brief Round a value up to the next integer (eq of ceil)
-     */
-    template<std::floating_point T>
-    constexpr T ROUND_UP(T value_)
+/**
+ * @brief Truncate a floating-point value (remove fractional part).
+ */
+template<std::floating_point T>
+constexpr T TRUNC(T value_)
+{
+    return (value_ == 0) ? value_ :  // Handle ±0.0
+               (value_ > 0) ? static_cast<T>(static_cast<int64_t>(value_))
+                            : static_cast<T>(static_cast<int64_t>(value_ - static_cast<T>(1.0)) + static_cast<T>(1.0));
+}
+
+/**
+ * @brief Round a floating-point value to the nearest integer
+ */
+template<std::floating_point T>
+constexpr T ROUND(T value_)
+{
+    T absValue = ABS(value_);
+    T fractionalPart = absValue - static_cast<int64_t>(absValue);
+
+    if (fractionalPart >= static_cast<T>(0.5))
     {
-        T integerPart = static_cast<T>(static_cast<int64_t>(value_));
-        if (value_ == integerPart)
-        {
-            return integerPart;
-        }
-        return (value_ > 0) ? integerPart + static_cast<T>(1) : integerPart;
+        return (value_ < 0) ? static_cast<T>(static_cast<int64_t>(value_) - 1) : static_cast<T>(static_cast<int64_t>(value_) + 1);
     }
+    return static_cast<T>(static_cast<int64_t>(value_));
+}
 
-    /**
-     * @brief Round a value down to the previous integer (eq of floor)
-     */
-    template<std::floating_point T>
-    constexpr T ROUND_DOWN(T value_)
+/**
+ * @brief Round a value up to the next integer (eq of ceil)
+ */
+template<std::floating_point T>
+constexpr T ROUND_UP(T value_)
+{
+    T integerPart = static_cast<T>(static_cast<int64_t>(value_));
+    if (value_ == integerPart)
     {
-        T integerPart = static_cast<T>(static_cast<int64_t>(value_));
-        if (value_ == integerPart)
-        {
-            return integerPart;
-        }
-        return (value_ < 0) ? integerPart - static_cast<T>(1) : integerPart;
+        return integerPart;
     }
+    return (value_ > 0) ? integerPart + static_cast<T>(1) : integerPart;
+}
+
+/**
+ * @brief Round a value down to the previous integer (eq of floor)
+ */
+template<std::floating_point T>
+constexpr T ROUND_DOWN(T value_)
+{
+    T integerPart = static_cast<T>(static_cast<int64_t>(value_));
+    if (value_ == integerPart)
+    {
+        return integerPart;
+    }
+    return (value_ < 0) ? integerPart - static_cast<T>(1) : integerPart;
+}
 
 #define MAP(x, in_min, in_max, out_min, out_max)                                                                  \
     (((float)(x) - (float)(in_min)) * ((float)(out_max) - (float)(out_min)) / ((float)(in_max) - (float)(in_min)) \
@@ -164,7 +159,5 @@ namespace RoverLib2
 #define GET_PACKAGE_SOURCE_DIR(package_name) \
     (ament_index_cpp::get_package_prefix(package_name) + "/../../src/rover/" + package_name)
 #endif  // defined(_linux_) && defined(RCLCPP_DEBUG
-
-}  // namespace RoverLib2
 
 #endif  // MACROS_HPP


### PR DESCRIPTION
This reverts commit 59b847ae36565c6a92d81a7e7332fc3c15f3ba92.

wrong fix for namespace issue, reverting