### PR TITLE
Working heading in UI

### DIFF
--- a/rover_gui/src/Global/Constant/other/map.html
+++ b/rover_gui/src/Global/Constant/other/map.html
@@ -532,14 +532,16 @@
           stopDynamicPathUpdates();
         });
 
-        bridge.gpsCallback.connect(function (lat, lon, heading) {
-          currentPosition.latitude = lat;
-          currentPosition.longitude = lon;
-          lastHeading = -heading;
+        bridge.gpsCallback.connect(function (lat, lon, headingDeg) {
+    currentPosition.latitude = lat;
+    currentPosition.longitude = lon;
 
-          const position = Cesium.Cartesian3.fromDegrees(lon, lat);
-          entity.position = position;
-          entity.billboard.rotation = -heading;
+    headingDeg = ((headingDeg % 360) + 360) % 360;
+    const headingRad = Cesium.Math.toRadians(headingDeg);
+    const cesiumRotation = headingRad - Math.PI/2;
+    entity.position = Cesium.Cartesian3.fromDegrees(lon, lat);
+    
+    entity.billboard.rotation = cesiumRotation % (2 * Math.PI);
 
           if (!viewInitialized) {
             try {

--- a/rover_sim/src/gps_test_pub.cpp
+++ b/rover_sim/src/gps_test_pub.cpp
@@ -3,56 +3,54 @@
 
 class GpsPublisher : public rclcpp::Node
 {
-public:
-  GpsPublisher()
-  : Node("gps_publisher"),
-    latitude_(45.404476),
-    longitude_(-71.888351),
-    satellite_(8),
-    fix_quality_(3),
-    heading_deg_(0.0)
-  {
-    publisher_ = this->create_publisher<rover_msgs::msg::Gps>("/rover/gps/position", 10);
-    timer_ = this->create_wall_timer(
-      std::chrono::seconds(1),
-      std::bind(&GpsPublisher::publish_gps, this));
-  }
-
-private:
-  void publish_gps()
-  {
-    auto msg = rover_msgs::msg::Gps();
-    msg.latitude    = latitude_;
-    msg.longitude   = longitude_;
-    msg.satellite   = satellite_;
-    msg.fix_quality = fix_quality_;
-
-    msg.heading = heading_deg_;
-
-    publisher_->publish(msg);
-
-    heading_deg_ += 20.0F;
-    if (heading_deg_ >= 360.0) {
-      heading_deg_ -= 360.0;
+  public:
+    GpsPublisher():
+        Node("gps_publisher"),
+        latitude_(45.404476),
+        longitude_(-71.888351),
+        satellite_(8),
+        fix_quality_(3),
+        heading_deg_(0.0)
+    {
+        publisher_ = this->create_publisher<rover_msgs::msg::Gps>("/rover/gps/position", 10);
+        timer_ = this->create_wall_timer(std::chrono::seconds(1), std::bind(&GpsPublisher::publish_gps, this));
     }
-  }
 
-  rclcpp::Publisher<rover_msgs::msg::Gps>::SharedPtr publisher_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  private:
+    void publish_gps()
+    {
+        auto msg = rover_msgs::msg::Gps();
+        msg.latitude = latitude_;
+        msg.longitude = longitude_;
+        msg.satellite = satellite_;
+        msg.fix_quality = fix_quality_;
 
-  // fixed GPS position and status
-  double latitude_;
-  double longitude_;
-  int    satellite_;
-  int    fix_quality_;
+        msg.heading = heading_deg_;
 
-  double heading_deg_;
+        publisher_->publish(msg);
+
+        heading_deg_ += 20.0F;
+        if (heading_deg_ >= 360.0)
+        {
+            heading_deg_ -= 360.0;
+        }
+    }
+
+    rclcpp::Publisher<rover_msgs::msg::Gps>::SharedPtr publisher_;
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    double latitude_;
+    double longitude_;
+    int satellite_;
+    int fix_quality_;
+
+    double heading_deg_;
 };
 
 int main(int argc, char* argv[])
 {
-  rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<GpsPublisher>());
-  rclcpp::shutdown();
-  return 0;
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<GpsPublisher>());
+    rclcpp::shutdown();
+    return 0;
 }

--- a/rover_sim/src/gps_test_pub.cpp
+++ b/rover_sim/src/gps_test_pub.cpp
@@ -3,38 +3,56 @@
 
 class GpsPublisher : public rclcpp::Node
 {
-  public:
-    GpsPublisher():
-        Node("gps_publisher"),
-        latitude_(45.404476)
-    {
-        publisher_ = this->create_publisher<rover_msgs::msg::Gps>("/rover/gps/position", 10);
-        timer_ = this->create_wall_timer(std::chrono::seconds(1), std::bind(&GpsPublisher::publish_gps, this));
+public:
+  GpsPublisher()
+  : Node("gps_publisher"),
+    latitude_(45.404476),
+    longitude_(-71.888351),
+    satellite_(8),
+    fix_quality_(3),
+    heading_deg_(0.0)
+  {
+    publisher_ = this->create_publisher<rover_msgs::msg::Gps>("/rover/gps/position", 10);
+    timer_ = this->create_wall_timer(
+      std::chrono::seconds(1),
+      std::bind(&GpsPublisher::publish_gps, this));
+  }
+
+private:
+  void publish_gps()
+  {
+    auto msg = rover_msgs::msg::Gps();
+    msg.latitude    = latitude_;
+    msg.longitude   = longitude_;
+    msg.satellite   = satellite_;
+    msg.fix_quality = fix_quality_;
+
+    msg.heading = heading_deg_;
+
+    publisher_->publish(msg);
+
+    heading_deg_ += 20.0F;
+    if (heading_deg_ >= 360.0) {
+      heading_deg_ -= 360.0;
     }
+  }
 
-  private:
-    void publish_gps()
-    {
-        auto msg = rover_msgs::msg::Gps();
-        msg.latitude = latitude_;
-        msg.longitude = -71.888351;
-        msg.satellite = 8;
-        msg.heading = M_PI;
-        msg.fix_quality = 3;
+  rclcpp::Publisher<rover_msgs::msg::Gps>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
-        publisher_->publish(msg);
-        latitude_ += 0.0001;
-    }
+  // fixed GPS position and status
+  double latitude_;
+  double longitude_;
+  int    satellite_;
+  int    fix_quality_;
 
-    rclcpp::Publisher<rover_msgs::msg::Gps>::SharedPtr publisher_;
-    rclcpp::TimerBase::SharedPtr timer_;
-    double latitude_;
+  double heading_deg_;
 };
 
 int main(int argc, char* argv[])
 {
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<GpsPublisher>());
-    rclcpp::shutdown();
-    return 0;
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<GpsPublisher>());
+  rclcpp::shutdown();
+  return 0;
 }


### PR DESCRIPTION
This pull request introduces improvements to the handling of GPS data and heading calculations in both the simulation and GUI components of the rover project. The changes ensure consistent heading representation in degrees and radians, improve modularity, and refine the simulation's GPS data publishing logic.

### Improvements to heading calculations in the GUI:

* [`rover_gui/src/Global/Constant/other/map.html`](diffhunk://#diff-f4abe7820ee07fcd17740d640815185e39c736a162421f747e30d81119fad2a1L535-R544): Updated the heading calculation to normalize degrees within the range [0, 360], convert them to radians, and adjust the Cesium billboard rotation accordingly. This ensures accurate and consistent rendering of the rover's orientation in the GUI.