### PR TITLE
Fixed simulation + matplotlib to provision

### DIFF
--- a/rover_sim/launch/sim.launch.py
+++ b/rover_sim/launch/sim.launch.py
@@ -35,7 +35,7 @@ def generate_launch_description():
     battery_arg = LaunchConfiguration(" battery")
 
 
-    '''
+
     arm_sim_node = Node(
         package="rover_sim",
         namespace="/rover/sim",
@@ -43,7 +43,6 @@ def generate_launch_description():
         name="arm_sim",
         condition=IfCondition(arm)
     )
-    '''
 
     gps_sim_node = Node(
         package="rover_sim",
@@ -70,7 +69,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(arm_arg)
     ld.add_action(gps_arg)
-    #ld.add_action(arm_sim_node)
+    ld.add_action(arm_sim_node)
     ld.add_action(gps_sim_node)
     ld.add_action(battery_sim_node)
     ld.add_action(connection_speed_sim_node)

--- a/rover_sim/scripts/arm_sim.py
+++ b/rover_sim/scripts/arm_sim.py
@@ -16,7 +16,7 @@ class ArmSimulation(Node):
         super().__init__("arm_simulation")
         
         self.goal_velocity = self.create_subscription(
-            ArmMsg, "/rover/arm/cmd/goal_speed", self.goalVelocityCallback, 10)        
+            ArmMsg, "/rover/arm/joints_cmd", self.goalVelocityCallback, 10)        
         
         self.current_position_publisher = self.create_publisher(
             ArmMsg, "/rover/arm/status/current_positions", 10)
@@ -42,12 +42,12 @@ class ArmSimulation(Node):
         self.dt = 0.1
 
     def goalVelocityCallback(self, msg):
-        assert len(msg.data) >= 5, f"Expected at least 5 elements in ArmMsg.data, got {len(msg.data)}"
+        assert len(msg.target_speed) >= 5, f"Expected at least 5 elements in ArmMsg.data, got {len(msg.target_speed)}"
 
-        self.linearJointVelocity = msg.data[ArmMsg.JL]
-        self.shoulderJointVelocity = msg.data[ArmMsg.J1]
-        self.elbowJointVelocity = msg.data[ArmMsg.J2]
-        self.gripperJointVelocity = msg.data[ArmMsg.GRIPPER_TILT]
+        self.linearJointVelocity = msg.target_speed[ArmMsg.JL]
+        self.shoulderJointVelocity = msg.target_speed[ArmMsg.J1]
+        self.elbowJointVelocity = msg.target_speed[ArmMsg.J2]
+        self.gripperJointVelocity = msg.target_speed[ArmMsg.GRIPPER_TILT]
 
         self.JL_pos += self.linearJointVelocity * self.dt
         self.J1_pos += self.shoulderJointVelocity * self.dt
@@ -67,7 +67,7 @@ class ArmSimulation(Node):
 
     def publish_joint_positions(self):
         msg = ArmMsg()
-        msg.data = [
+        msg.target_speed = [
             self.JL_pos,    # JL
             0.0,            # BASE (unused)
             self.J1_pos,    # J1
@@ -80,10 +80,10 @@ class ArmSimulation(Node):
         self.current_position_publisher.publish(msg)
 
         qPosition = np.array([
-            msg.data[ArmMsg.JL],
-            msg.data[ArmMsg.J1],
-            msg.data[ArmMsg.J2],
-            msg.data[ArmMsg.GRIPPER_TILT]
+            msg.target_speed[ArmMsg.JL],
+            msg.target_speed[ArmMsg.J1],
+            msg.target_speed[ArmMsg.J2],
+            msg.target_speed[ArmMsg.GRIPPER_TILT]
         ])
         pointPos = self.computeDirectKin(qPosition)
         self.plot(pointPos)

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -42,6 +42,7 @@ echo -e "\e[0;32m[OK]\e[0m"
 echo "=== Installing dep from pip ... ==="
 pip install --upgrade setuptools==58.2.0
 pip install python-can
+pip install matplotlib
 echo -e "\e[0;32m[OK]\e[0m"
 
 echo -e "=== \e[0;32m[SUCCESS]\e[0m Depedencies updated ==="


### PR DESCRIPTION
This pull request includes updates to the `rover_sim` package to re-enable the arm simulation, refactor the `ArmMsg` message structure, and improve the provisioning script. The changes primarily focus on restoring functionality, improving maintainability, and adding dependencies for visualization.

### Simulation Launch Updates:
* Re-enabled the `arm_sim_node` in the `generate_launch_description` function by uncommenting its definition and adding it to the launch description (`rover_sim/launch/sim.launch.py`). [[1]](diffhunk://#diff-9efd9eba4c64fc28c2ddad5fd89468f360ef918d2628341e8ffb24e71afb8051L38-L46) [[2]](diffhunk://#diff-9efd9eba4c64fc28c2ddad5fd89468f360ef918d2628341e8ffb24e71afb8051L73-R72)

### `ArmMsg` Refactor:
* Updated the subscription topic for receiving arm commands from `/rover/arm/cmd/goal_speed` to `/rover/arm/joints_cmd` (`rover_sim/scripts/arm_sim.py`).
* Refactored `ArmMsg` usage to replace `data` with `target_speed` for clarity and consistency in callback and publishing logic (`rover_sim/scripts/arm_sim.py`). [[1]](diffhunk://#diff-60f5e0761e854078f050b0c4fe334500cbc9171f2011fd1789c3c55a7940c776L45-R50) [[2]](diffhunk://#diff-60f5e0761e854078f050b0c4fe334500cbc9171f2011fd1789c3c55a7940c776L70-R70) [[3]](diffhunk://#diff-60f5e0761e854078f050b0c4fe334500cbc9171f2011fd1789c3c55a7940c776L83-R86)

### Provisioning Script Enhancement:
* Added the `matplotlib` library to the provisioning script to support visualization needs (`scripts/provision.sh`).