### PR TITLE
Fixing waypoints from JS --> Qt

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,7 +59,7 @@ SpacesInCStyleCastParentheses: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: Cpp20
+Standard: c++20
 TabWidth: '2'
 UseTab: Never
 SortIncludes: 'false'

--- a/rover_gui/src/Global/Constant/other/JS/bridge.js
+++ b/rover_gui/src/Global/Constant/other/JS/bridge.js
@@ -32,57 +32,62 @@ class Bridge
             const qtBridge = channel.objects.bridge;
             window.qtBridge = qtBridge;
 
-            const self = this;
-
-            qtBridge.clearPath.connect(function () 
+            qtBridge.clearPath.connect(() =>
             {
-                self.pathManager.stopDynamicWaypointPathUpdates();
+                this.pathManager.stopDynamicWaypointPathUpdates();
             });
 
-            qtBridge.gpsCallback.connect(function (lat, lon, headingDeg) 
+            qtBridge.gpsCallback.connect((lat, lon, headingDeg) => 
             {
-                self.#gpsCallback(lat, lon, headingDeg);
+                this.#gpsCallback(lat, lon, headingDeg);
             });
 
-            qtBridge.sendGoal.connect(function (name, lat, lon, id, flyTo) 
+            qtBridge.sendGoal.connect((name, lat, lon, id, flyTo) => 
             {
-                self.#setGoal(name, lat, lon, id, flyTo);
+                this.#setGoal(name, lat, lon, id, flyTo);
             });
 
-            qtBridge.calculatePath.connect(function (destLat, destLon, waypointId) 
+            qtBridge.calculatePath.connect((destLat, destLon, waypointId) => 
             {
-                self.pathManager.startDynamicWaypointPathUpdates(destLat, destLon, waypointId);
+                this.pathManager.startDynamicWaypointPathUpdates(destLat, destLon, waypointId);
             });
 
-            qtBridge.clearWaypoints.connect(function () 
+            qtBridge.clearWaypoints.connect(() => 
             {
-                self.waypoints.clearAllWaypoints();
-                self.pathManager.stopDynamicWaypointPathUpdates();
-                self.pathManager.clearWaypointPath();
+                Swal.fire({
+                    title: 'Waypoints cleared',
+                    text: `All waypoints have been removed.`,
+                    icon: 'success',
+                    confirmButtonText: 'OK'
+                });
+
+                this.waypoints.clearAllWaypoints();
+                this.pathManager.stopDynamicWaypointPathUpdates();
+                this.pathManager.clearWaypointPath();
             });
 
-            qtBridge.deleteWaypoint.connect(function (waypointId) 
+            qtBridge.deleteWaypoint.connect((waypointId) =>
             {
-                if (self.waypoints.activeWaypoint && self.waypoints.activeWaypoint.id === waypointId) 
+                if (this.waypoints.activeWaypoint && this.waypoints.activeWaypoint.id === waypointId) 
                 {
-                    self.pathManager.stopDynamicWaypointPathUpdates();
+                    this.pathManager.stopDynamicWaypointPathUpdates();
                 }
-                self.waypoints.deleteWaypoint(waypointId);
+                this.waypoints.deleteWaypoint(waypointId);
             });
 
-            qtBridge.waypointIsVisible.connect(function (waypointId, visibility)
+            qtBridge.waypointIsVisible.connect((waypointId, visibility) =>
             {
-                self.waypoints.waypointVisibility(waypointId, visibility);
+                this.waypoints.waypointVisibility(waypointId, visibility);
             });
 
-            qtBridge.updatePathTaken.connect(function (latitude_, longitude_)
+            qtBridge.updatePathTaken.connect((latitude_, longitude_) =>
             {
-                self.pathManager.drawPathTaken(latitude_, longitude_);
+                this.pathManager.drawPathTaken(latitude_, longitude_);
             });
 
-            qtBridge.loadFullPath.connect(function (points_)
+            qtBridge.loadFullPath.connect((points_) =>
             {
-               self.pathManager.drawFullPath(points_) 
+               this.pathManager.drawFullPath(points_) 
             });
 
             if (window.qtBridge && window.qtBridge.onJsBridgeReady) 

--- a/rover_gui/src/Global/Constant/other/JS/bridge.js
+++ b/rover_gui/src/Global/Constant/other/JS/bridge.js
@@ -54,13 +54,6 @@ class Bridge
 
             qtBridge.clearWaypoints.connect(() => 
             {
-                Swal.fire({
-                    title: 'Waypoints cleared',
-                    text: `All waypoints have been removed.`,
-                    icon: 'success',
-                    confirmButtonText: 'OK'
-                });
-
                 this.waypoints.clearAllWaypoints();
                 this.pathManager.stopDynamicWaypointPathUpdates();
                 this.pathManager.clearWaypointPath();

--- a/rover_gui/src/Global/Constant/other/JS/map.js
+++ b/rover_gui/src/Global/Constant/other/JS/map.js
@@ -41,7 +41,7 @@ async function checkConnectivity()
 
 document.addEventListener('DOMContentLoaded', initializeMap);
 
-window.addEventListener('offline', function () 
+window.addEventListener('offline', () => 
 {
     const connectionError = document.getElementById('connectionError');
     if (connectionError)
@@ -50,7 +50,7 @@ window.addEventListener('offline', function ()
     }
 });
 
-window.addEventListener('online', async function () {
+window.addEventListener('online', async () => {
     const connection = await checkConnectivity();
     if (connection)
     {

--- a/rover_gui/src/Global/Helpers/QHelpers.cpp
+++ b/rover_gui/src/Global/Helpers/QHelpers.cpp
@@ -9,6 +9,7 @@
 #include <QProcess>
 #include <QString>
 #include <QTimer>
+#include <QThread>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -19,27 +20,23 @@ namespace QHelper
                                                           const std::string& message_,
                                                           QMessageBox::StandardButtons buttons_)
     {
-        QEventLoop waitForAnswerLoop;
-        QMessageBox::StandardButton userSelection = QMessageBox::StandardButton::NoButton;
+        QMessageBox::StandardButton userSelection = QMessageBox::NoButton;
 
-        QCoreApplication* pApp = QApplication::instance();
-        if (pApp)
+        auto showDialog = [&]()
         {
-            QMetaObject::invokeMethod(pApp,
-                                      [&]()
-                                      {
-                                          userSelection = QMessageBox::question(nullptr,
-                                                                                QString::fromStdString(title_),
-                                                                                QString::fromStdString(message_),
-                                                                                buttons_);
-                                          waitForAnswerLoop.quit();
-                                      });
-            QObject::connect(pApp, &QCoreApplication::aboutToQuit, &waitForAnswerLoop, &QEventLoop::quit);
-            waitForAnswerLoop.exec();
+            userSelection
+                = QMessageBox::question(nullptr, QString::fromStdString(title_), QString::fromStdString(message_), buttons_);
+        };
+
+        if (QThread::currentThread() == QCoreApplication::instance()->thread())
+        {
+            // Already on main thread, call directly
+            showDialog();
         }
         else
         {
-            RCLCPP_ERROR(rclcpp::get_logger("GUI"), "QApplication returned null, something is very wrong");
+            // Cross-thread: block calling thread until main thread completes
+            QMetaObject::invokeMethod(QCoreApplication::instance(), showDialog, Qt::BlockingQueuedConnection);
         }
 
         return userSelection;
@@ -50,47 +47,39 @@ namespace QHelper
                                       OUT std::string& input_,
                                       const bool passwordMode_)
     {
-        bool success = true;
-        QEventLoop waitForAnswerLoop;
+        bool success = false;
 
-        QCoreApplication* pApp = QApplication::instance();
-        if (!pApp)
+        auto showDialog = [&]()
         {
-            RCLCPP_ERROR(rclcpp::get_logger("GUI"), "QApplication returned null, something is very wrong");
-            success = false;
+            QInputDialog inputDialog;
+            inputDialog.setWindowTitle(QString::fromStdString(title_));
+            inputDialog.setLabelText(QString::fromStdString(message_));
+
+            if (passwordMode_)
+            {
+                QLineEdit* pLineEdit = inputDialog.findChild<QLineEdit*>();
+                if (pLineEdit)
+                    pLineEdit->setEchoMode(QLineEdit::Password);
+            }
+
+            if (inputDialog.exec() == QDialog::Accepted)
+            {
+                input_ = inputDialog.textValue().toStdString();
+                success = true;
+            }
+            else
+            {
+                input_ = "";
+            }
+        };
+
+        if (QThread::currentThread() == QCoreApplication::instance()->thread())
+        {
+            showDialog();
         }
         else
         {
-            QMetaObject::invokeMethod(pApp,
-                                      [&]()
-                                      {
-                                          QInputDialog inputDialog;
-                                          inputDialog.setWindowTitle(QString::fromStdString(title_));
-                                          inputDialog.setLabelText(QString::fromStdString(message_));
-
-                                          if (passwordMode_)
-                                          {
-                                              QLineEdit* plineEdit = inputDialog.findChild<QLineEdit*>();
-                                              if (plineEdit)
-                                              {
-                                                  plineEdit->setEchoMode(QLineEdit::Password);
-                                              }
-                                          }
-
-                                          if (inputDialog.exec() == QDialog::Accepted)
-                                          {
-                                              input_ = inputDialog.textValue().toStdString();
-                                          }
-                                          else
-                                          {
-                                              input_ = "";
-                                              success = false;
-                                          }
-
-                                          waitForAnswerLoop.quit();
-                                      });
-
-            waitForAnswerLoop.exec();
+            QMetaObject::invokeMethod(QCoreApplication::instance(), showDialog, Qt::BlockingQueuedConnection);
         }
 
         return success;

--- a/rover_gui/src/QNavigation/QNavigation.cpp
+++ b/rover_gui/src/QNavigation/QNavigation.cpp
@@ -213,9 +213,8 @@ void QNavigation::pathDistanceCalculated(double distanceMeters_, double heading_
     _ui.distanceLabel->setText(distanceText_);
 }
 
-void QNavigation::waypointCreated(const QString& name_, double latitude_, double longitude_, QString& id_)
+void QNavigation::waypointCreated(const QString& name_, double latitude_, double longitude_, const QString& id_)
 {
-    RCLCPP_ERROR(this->_node->get_logger(), "Received signal from bridge");
     for (const auto& waypoint : _waypointsList)
     {
         if (waypoint.id == id_.toStdString() || waypoint.name == name_.toStdString())
@@ -224,16 +223,10 @@ void QNavigation::waypointCreated(const QString& name_, double latitude_, double
         }
     }
 
-    if (id_.isEmpty())
-    {
-        id_ = "waypoint_" + QUuid::createUuid().toString(QUuid::WithoutBraces);
-    }
-    sWaypoint waypoint = {name_.toStdString(), latitude_, longitude_, id_.toStdString()};
-    RCLCPP_ERROR(rclcpp::get_logger("GUI"),
-                 "Correctly passed through waypointCreated(): name: %s, latitude: %f, longitude: %f",
-                 waypoint.name.c_str(),
-                 waypoint.latitude,
-                 waypoint.longitude);
+    std::string id;
+    id = id_.isEmpty() ? "waypoint_" + QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString() : id_.toStdString();
+    
+    sWaypoint waypoint = {name_.toStdString(), latitude_, longitude_, id};
     this->addWaypointToList(waypoint);
     _waypointManager.syncWaypoints(_waypointsList);
 }
@@ -361,11 +354,9 @@ void QNavigation::onDeleteWaypointClicked(void)
 
 void QNavigation::onClearWaypointsClicked(void)
 {
-    RCLCPP_ERROR(this->_node->get_logger(), "Before popup");
     QMessageBox::StandardButton result_ = QHelper::QPopUp::sendQuestionPopUp("Clear Waypoints",
                                                                              "Are you sure you want to clear all waypoints?",
                                                                              QMessageBox::Yes | QMessageBox::No);
-    RCLCPP_ERROR(this->_node->get_logger(), "After popup");
 
     if (result_ == QMessageBox::Yes)
     {
@@ -380,10 +371,7 @@ void QNavigation::onClearWaypointsClicked(void)
 
         emit this->clearWaypoints();
 
-        RCLCPP_ERROR(this->_node->get_logger(), "Cleared all waypoints");
     }
-
-    RCLCPP_ERROR(this->_node->get_logger(), "Not cleared all waypoints");
 }
 
 void QNavigation::onWebViewLoadFinished(bool ok_)

--- a/rover_gui/src/QNavigation/QNavigation.cpp
+++ b/rover_gui/src/QNavigation/QNavigation.cpp
@@ -225,7 +225,7 @@ void QNavigation::waypointCreated(const QString& name_, double latitude_, double
 
     std::string id;
     id = id_.isEmpty() ? "waypoint_" + QUuid::createUuid().toString(QUuid::WithoutBraces).toStdString() : id_.toStdString();
-    
+
     sWaypoint waypoint = {name_.toStdString(), latitude_, longitude_, id};
     this->addWaypointToList(waypoint);
     _waypointManager.syncWaypoints(_waypointsList);
@@ -370,7 +370,6 @@ void QNavigation::onClearWaypointsClicked(void)
         _ui.distanceLabel->setText("N/A");
 
         emit this->clearWaypoints();
-
     }
 }
 

--- a/rover_gui/src/QNavigation/QNavigation.cpp
+++ b/rover_gui/src/QNavigation/QNavigation.cpp
@@ -215,6 +215,7 @@ void QNavigation::pathDistanceCalculated(double distanceMeters_, double heading_
 
 void QNavigation::waypointCreated(const QString& name_, double latitude_, double longitude_, QString& id_)
 {
+    RCLCPP_ERROR(this->_node->get_logger(), "Received signal from bridge");
     for (const auto& waypoint : _waypointsList)
     {
         if (waypoint.id == id_.toStdString() || waypoint.name == name_.toStdString())
@@ -360,9 +361,11 @@ void QNavigation::onDeleteWaypointClicked(void)
 
 void QNavigation::onClearWaypointsClicked(void)
 {
+    RCLCPP_ERROR(this->_node->get_logger(), "Before popup");
     QMessageBox::StandardButton result_ = QHelper::QPopUp::sendQuestionPopUp("Clear Waypoints",
                                                                              "Are you sure you want to clear all waypoints?",
                                                                              QMessageBox::Yes | QMessageBox::No);
+    RCLCPP_ERROR(this->_node->get_logger(), "After popup");
 
     if (result_ == QMessageBox::Yes)
     {
@@ -376,7 +379,11 @@ void QNavigation::onClearWaypointsClicked(void)
         _ui.distanceLabel->setText("N/A");
 
         emit this->clearWaypoints();
+
+        RCLCPP_ERROR(this->_node->get_logger(), "Cleared all waypoints");
     }
+
+    RCLCPP_ERROR(this->_node->get_logger(), "Not cleared all waypoints");
 }
 
 void QNavigation::onWebViewLoadFinished(bool ok_)

--- a/rover_gui/src/QNavigation/QNavigation.hpp
+++ b/rover_gui/src/QNavigation/QNavigation.hpp
@@ -39,7 +39,7 @@ class QNavigation : public QWidget
 
   public slots:
     void pathDistanceCalculated(double distanceMeters_, double heading_);
-    void waypointCreated(const QString& name_, double latitude_, double longitude_, QString& id_);
+    void waypointCreated(const QString& name_, double latitude_, double longitude_, const QString& id_);
     void onCalculatePathClicked(void);
     void onWaypointVisibilityChanged(QListWidgetItem* item_);
     void onWaypointSelected(QListWidgetItem* item_);


### PR DESCRIPTION
While fixing waypoints, found a second problem. PopUps were not returning until app was closed.

Explanation by Claude:

# What broke moving from Qt5 on Ubuntu 22.04 to Qt6 on Ubuntu 24.04
## Problem 1 — waypointCreated slot never firing

```cpp
void waypointCreated(const QString& name_, double latitude_, double longitude_, QString& id_);
void waypointCreated(const QString& name_, double latitude_, double longitude_, const QString& id_);
```

The slot had a QString& (non-const reference) parameter. QWebChannel works by deserializing JSON into temporary values and injecting them into slot calls — there's no persistent object to hand a reference to. Qt5 let this slip through, Qt6 strictly validates that all slot parameters are serializable types and silently rejects the slot if they aren't. Fixed by changing QString& to const QString&, which is valid because C++ allows const references to bind to temporaries with extended lifetime.

## Problem 2 — sendQuestionPopUp blocking forever
The old code used QMetaObject::invokeMethod with a nested QEventLoop to simulate blocking. In Qt5, invokeMethod with a lambda defaulted to Qt::DirectConnection when called from the main thread, so the lambda ran synchronously before waitForAnswerLoop.exec() was even reached. In Qt6, lambda overloads default to Qt::QueuedConnection, so the lambda gets posted to the event queue instead — the QEventLoop starts spinning, the dialog opens fine, but the quit signal and the app's aboutToQuit interact in a way that breaks the unblocking, causing it to hang until app shutdown.
Fixed by ditching the nested QEventLoop entirely and replacing it with a direct call check plus Qt::BlockingQueuedConnection for cross-thread cases:

If already on the main thread → call QMessageBox::question directly
If on a worker thread → use Qt::BlockingQueuedConnection which blocks the calling thread and posts to the main thread's event loop, then resumes the caller when the dialog returns

This matters especially for QSshWorker, where the popup is called from background worker tasks that genuinely need the user's answer before deciding whether to continue the file transfer.